### PR TITLE
qgspointxy to qgspoint and Z value attempt

### DIFF
--- a/speckle/geometry.py
+++ b/speckle/geometry.py
@@ -1,4 +1,4 @@
-from qgis.core import QgsPointXY, QgsMultiPolygon, QgsWkbTypes, QgsMultiPoint, QgsPolygon, QgsLineString, QgsMultiLineString, QgsGeometry
+from qgis.core import QgsPoint, QgsMultiPolygon, QgsWkbTypes, QgsMultiPoint, QgsPolygon, QgsLineString, QgsMultiLineString, QgsGeometry
 
 from specklepy.objects.geometry import Point, Polyline
 from .logging import log
@@ -34,8 +34,8 @@ def extractGeometry(feature):
         print("Unknown or invalid geometry")
     return None
 
-def pointToSpeckle(pt: QgsPointXY):
-    return Point(pt.x(),pt.y())
+def pointToSpeckle(pt: QgsPoint):
+    return Point(pt.x(),pt.y(),pt.z())
 
 def polylineFromVertices(vertices, closed):
     specklePts = [pointToSpeckle(pt) for pt in vertices]


### PR DESCRIPTION
I found that I could not get Z values to transfer. Reading up on it and poking through the code I noticed that you were using qgspointxy. It seemed like if qgspoint was used instead it would allow for z values: https://qgis.org/pyqgis/3.2/core/Point/QgsPointXY.html https://gis.stackexchange.com/questions/377881/whats-the-difference-between-qgspoint-qgspointxy-and-qgsgeometry-frompointxyq 

By changing to qgspoint and adding pt.z() I was able to get polylines with z values to show in both speckle and blender. 

However that made geometry without z values not work (GIS data often does not have z values) and point data with or without z values no longer works. 

I am adding this as a pull request even though it breaks things so you can see the changes I made in case they are any help.  I hope that is not a problem and I am not leading you down the wrong path here. I have only taken one python GIS programing class. 

If you have any ideas about what would fix those thing I am happy to try them out and keep poking at this. 